### PR TITLE
Fix horizontal margins for images overflowing

### DIFF
--- a/_scss/main.scss
+++ b/_scss/main.scss
@@ -60,6 +60,9 @@ div.nav {
     margin: 0 2em;
     > div, > img {
         margin: 1em 2em;
+        @media only screen and (max-width: 950px) {
+            margin: 1em auto;
+        }
         max-width: 600pt;
     }
     > img {


### PR DESCRIPTION
This was a mobile patch to fix issues of images causing a whitespace and overflowing over the normal mobile viewport. By setting it to "auto," this fixes the issue with margins.